### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -882,15 +882,15 @@
       }
     },
     "node_modules/@backstage/plugin-auth-node/node_modules/@backstage/backend-common": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-      "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+      "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
-        "@backstage/config-loader": "^1.0.0",
+        "@backstage/config-loader": "^1.1.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
         "@backstage/types": "^1.0.0",
         "@google-cloud/storage": "^5.8.0",
         "@keyv/redis": "^2.2.3",
@@ -900,6 +900,7 @@
         "@types/dockerode": "^3.3.0",
         "@types/express": "^4.17.6",
         "@types/luxon": "^2.0.4",
+        "@types/webpack-env": "^1.15.2",
         "archiver": "^5.0.2",
         "aws-sdk": "^2.840.0",
         "compression": "^1.7.4",
@@ -942,30 +943,30 @@
       }
     },
     "node_modules/@backstage/plugin-auth-node/node_modules/@backstage/catalog-model": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.0.tgz",
-      "integrity": "sha512-hjvTzs+P1/TG42FhX6jJvRIBbYZJC0vE9Qqn9MTb4n8vaoZuBT5jYTnK6K80gpEyNfbznpD5vsE8ss5lmzWz+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.1.tgz",
+      "integrity": "sha512-VxKQ+WzcsxAWtwWyeGw04vTefkmwxi6XweXSNRhNddXAVqsAbDcCYBUc9jylu0bYVXXWYJkEl8kiwyawUloPPQ==",
       "dependencies": {
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
         "@backstage/types": "^1.0.0",
-        "ajv": "^7.0.3",
+        "ajv": "^8.10.0",
         "json-schema": "^0.4.0",
         "lodash": "^4.17.21",
         "uuid": "^8.0.0"
       }
     },
     "node_modules/@backstage/plugin-auth-node/node_modules/@backstage/config-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-      "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+      "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
         "@backstage/types": "^1.0.0",
         "@types/json-schema": "^7.0.6",
-        "ajv": "^7.0.3",
+        "ajv": "^8.10.0",
         "chokidar": "^3.5.2",
         "fs-extra": "10.0.1",
         "json-schema": "^0.4.0",
@@ -988,9 +989,9 @@
       }
     },
     "node_modules/@backstage/plugin-auth-node/node_modules/@backstage/integration": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-      "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+      "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
       "dependencies": {
         "@backstage/config": "^1.0.0",
         "@octokit/auth-app": "^3.4.0",
@@ -1005,6 +1006,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
       "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+    },
+    "node_modules/@backstage/plugin-auth-node/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/@backstage/plugin-auth-node/node_modules/fs-extra": {
       "version": "10.0.1",
@@ -1268,15 +1284,15 @@
       }
     },
     "node_modules/@backstage/plugin-permission-node/node_modules/@backstage/backend-common": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-      "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+      "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
-        "@backstage/config-loader": "^1.0.0",
+        "@backstage/config-loader": "^1.1.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
         "@backstage/types": "^1.0.0",
         "@google-cloud/storage": "^5.8.0",
         "@keyv/redis": "^2.2.3",
@@ -1286,6 +1302,7 @@
         "@types/dockerode": "^3.3.0",
         "@types/express": "^4.17.6",
         "@types/luxon": "^2.0.4",
+        "@types/webpack-env": "^1.15.2",
         "archiver": "^5.0.2",
         "aws-sdk": "^2.840.0",
         "compression": "^1.7.4",
@@ -1328,16 +1345,16 @@
       }
     },
     "node_modules/@backstage/plugin-permission-node/node_modules/@backstage/config-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-      "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+      "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
         "@backstage/types": "^1.0.0",
         "@types/json-schema": "^7.0.6",
-        "ajv": "^7.0.3",
+        "ajv": "^8.10.0",
         "chokidar": "^3.5.2",
         "fs-extra": "10.0.1",
         "json-schema": "^0.4.0",
@@ -1360,9 +1377,9 @@
       }
     },
     "node_modules/@backstage/plugin-permission-node/node_modules/@backstage/integration": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-      "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+      "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
       "dependencies": {
         "@backstage/config": "^1.0.0",
         "@octokit/auth-app": "^3.4.0",
@@ -1377,6 +1394,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
       "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+    },
+    "node_modules/@backstage/plugin-permission-node/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/@backstage/plugin-permission-node/node_modules/fs-extra": {
       "version": "10.0.1",
@@ -1492,15 +1524,15 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend-module-cookiecutter/-/plugin-scaffolder-backend-module-cookiecutter-0.2.5.tgz",
-      "integrity": "sha512-/44EU1AX9YIBo54jlVPCpHvMyMeD148UvAYhnTYJ9E4iE58MLdmSx6AyL0WSJ7VeODOyDvsy6xc4XOf+3+30PQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend-module-cookiecutter/-/plugin-scaffolder-backend-module-cookiecutter-0.2.6.tgz",
+      "integrity": "sha512-vp7yvk6hYzzYNzebSUOTfv4Ejd070s+9250RePBn7MYeJM7JWRjSzR948mxYIMnjpD+1C1AHmzMxWypo7BcsUA==",
       "dependencies": {
-        "@backstage/backend-common": "^0.13.1",
+        "@backstage/backend-common": "^0.13.2",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
-        "@backstage/plugin-scaffolder-backend": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
+        "@backstage/plugin-scaffolder-backend": "^1.1.0",
         "@backstage/types": "^1.0.0",
         "command-exists": "^1.2.9",
         "fs-extra": "10.0.1",
@@ -1509,15 +1541,15 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/backend-common": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-      "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+      "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
-        "@backstage/config-loader": "^1.0.0",
+        "@backstage/config-loader": "^1.1.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
         "@backstage/types": "^1.0.0",
         "@google-cloud/storage": "^5.8.0",
         "@keyv/redis": "^2.2.3",
@@ -1527,6 +1559,7 @@
         "@types/dockerode": "^3.3.0",
         "@types/express": "^4.17.6",
         "@types/luxon": "^2.0.4",
+        "@types/webpack-env": "^1.15.2",
         "archiver": "^5.0.2",
         "aws-sdk": "^2.840.0",
         "compression": "^1.7.4",
@@ -1569,40 +1602,40 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/catalog-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/catalog-client/-/catalog-client-1.0.0.tgz",
-      "integrity": "sha512-m2FiV9+gQElYrZMICFpr3Dj7H34as9Jly1onF/yFhKi4DSovZpgemTG6I0KQuNuEwmrqYTkTd6kDDYvpUis9Ow==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@backstage/catalog-client/-/catalog-client-1.0.1.tgz",
+      "integrity": "sha512-2JUEqtR3v361JM6JDjTt8k/tlZd27RB/ZQ2Vwp5seJf4QYXfR9s5AM4M35l/A5vosDKhGrxMAq3t2s4gcH9vVg==",
       "dependencies": {
-        "@backstage/catalog-model": "^1.0.0",
+        "@backstage/catalog-model": "^1.0.1",
         "@backstage/errors": "^1.0.0",
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/catalog-model": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.0.tgz",
-      "integrity": "sha512-hjvTzs+P1/TG42FhX6jJvRIBbYZJC0vE9Qqn9MTb4n8vaoZuBT5jYTnK6K80gpEyNfbznpD5vsE8ss5lmzWz+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.1.tgz",
+      "integrity": "sha512-VxKQ+WzcsxAWtwWyeGw04vTefkmwxi6XweXSNRhNddXAVqsAbDcCYBUc9jylu0bYVXXWYJkEl8kiwyawUloPPQ==",
       "dependencies": {
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
         "@backstage/types": "^1.0.0",
-        "ajv": "^7.0.3",
+        "ajv": "^8.10.0",
         "json-schema": "^0.4.0",
         "lodash": "^4.17.21",
         "uuid": "^8.0.0"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/config-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-      "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+      "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
       "dependencies": {
         "@backstage/cli-common": "^0.1.8",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
         "@backstage/types": "^1.0.0",
         "@types/json-schema": "^7.0.6",
-        "ajv": "^7.0.3",
+        "ajv": "^8.10.0",
         "chokidar": "^3.5.2",
         "fs-extra": "10.0.1",
         "json-schema": "^0.4.0",
@@ -1625,9 +1658,9 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/integration": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-      "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+      "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
       "dependencies": {
         "@backstage/config": "^1.0.0",
         "@octokit/auth-app": "^3.4.0",
@@ -1638,22 +1671,35 @@
         "luxon": "^2.0.2"
       }
     },
-    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-catalog-backend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.0.0.tgz",
-      "integrity": "sha512-YFZpRiJPVl38wFbb/IM8Sb1xTdXfXhH3AHNhuO/M38l3I2ThkhJnkUt3QWA+mIyf0k2q0xtawvjJU/6pqwAo6A==",
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-auth-node": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-auth-node/-/plugin-auth-node-0.2.0.tgz",
+      "integrity": "sha512-aYfC3Hx9De78gofRB0DAIjyTD09XnRLxbjK2JCz9An6eVdX/DOWI8iwwNN07Qem0haLsGNVBhofUuuqQYpfw8w==",
       "dependencies": {
-        "@backstage/backend-common": "^0.13.1",
-        "@backstage/catalog-client": "^1.0.0",
-        "@backstage/catalog-model": "^1.0.0",
+        "@backstage/backend-common": "^0.13.2",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
-        "@backstage/plugin-catalog-common": "^1.0.0",
-        "@backstage/plugin-permission-common": "^0.5.3",
-        "@backstage/plugin-permission-node": "^0.5.5",
-        "@backstage/plugin-scaffolder-common": "^1.0.0",
-        "@backstage/plugin-search-common": "^0.3.2",
+        "jose": "^1.27.1",
+        "node-fetch": "^2.6.7",
+        "winston": "^3.2.1"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-catalog-backend": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.1.1.tgz",
+      "integrity": "sha512-o81MnzcdAY3vWyH2H//vHyI/dYQhfXf21PylGPLdDqQgHuxh9yNeM7OlKSeqmpbHBVkvl+vjzrpZUTmrNvKMQg==",
+      "dependencies": {
+        "@backstage/backend-common": "^0.13.2",
+        "@backstage/catalog-client": "^1.0.1",
+        "@backstage/catalog-model": "^1.0.1",
+        "@backstage/config": "^1.0.0",
+        "@backstage/errors": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
+        "@backstage/plugin-catalog-common": "^1.0.1",
+        "@backstage/plugin-permission-common": "^0.6.0",
+        "@backstage/plugin-permission-node": "^0.6.0",
+        "@backstage/plugin-scaffolder-common": "^1.0.1",
+        "@backstage/plugin-search-common": "^0.3.3",
         "@backstage/types": "^1.0.0",
         "@types/express": "^4.17.6",
         "codeowners-utils": "^1.0.2",
@@ -1678,29 +1724,57 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-catalog-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.0.tgz",
-      "integrity": "sha512-XKBMlh/2RMJ8Nkc6n/hYS07To+MVe2oCp3tHJpmXYzYe0Uc8nfE09iam26n9Kz/mtcmlIP2LJcjYW2mq1k2vnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.1.tgz",
+      "integrity": "sha512-zPf8OGSjH+ZftMnjBxTgwLtgapnO1L7fzulLQ2RRaWrUcXGk8N3szQBDcqwxfBFiWSIX1G4vvRi/BGXFMUMlnw==",
       "dependencies": {
-        "@backstage/plugin-permission-common": "^0.5.3",
-        "@backstage/search-common": "^0.3.2"
+        "@backstage/plugin-permission-common": "^0.6.0",
+        "@backstage/search-common": "^0.3.3"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-permission-common": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.0.tgz",
+      "integrity": "sha512-wx5TUDFilRqmMJP8TxjR5GuulFFOPHNwoK6eNMuz5ESzLzPhiJDovqaXjqpxsdCVGNb2VJOUlND3SzbwjQ65aA==",
+      "dependencies": {
+        "@backstage/config": "^1.0.0",
+        "@backstage/errors": "^1.0.0",
+        "cross-fetch": "^3.1.5",
+        "uuid": "^8.0.0",
+        "zod": "^3.11.6"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-permission-node": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-node/-/plugin-permission-node-0.6.0.tgz",
+      "integrity": "sha512-3NUa+0YjYZ9N0MqyKMTsnfrxzCtcahZVPowEXduELvqJ/L4K6pRFFwI+/g+wmLXKmt72eDceuwEa/ZEFsxbKTg==",
+      "dependencies": {
+        "@backstage/backend-common": "^0.13.2",
+        "@backstage/config": "^1.0.0",
+        "@backstage/errors": "^1.0.0",
+        "@backstage/plugin-auth-node": "^0.2.0",
+        "@backstage/plugin-permission-common": "^0.6.0",
+        "@types/express": "^4.17.6",
+        "express": "^4.17.1",
+        "express-promise-router": "^4.1.0",
+        "zod": "^3.11.6"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-scaffolder-backend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend/-/plugin-scaffolder-backend-1.0.0.tgz",
-      "integrity": "sha512-XBO0xEYJKml2pZ4Akkgt47SmGN4p6seQCBmWKcOzm6lYtjAPV4dxv5JlwNWmoQDJ1KCNh2/hmuBAcoWIIZl/nA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend/-/plugin-scaffolder-backend-1.1.0.tgz",
+      "integrity": "sha512-Jt1TthxzxxfxOGh46ZkmHFmdGl48tyObgO5MCqntoITzp5Plbm0/Kx4jwAJ3CFfLonulJ+tA91g63MBOYueugw==",
       "dependencies": {
-        "@backstage/backend-common": "^0.13.1",
-        "@backstage/catalog-client": "^1.0.0",
-        "@backstage/catalog-model": "^1.0.0",
+        "@backstage/backend-common": "^0.13.2",
+        "@backstage/catalog-client": "^1.0.1",
+        "@backstage/catalog-model": "^1.0.1",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
-        "@backstage/plugin-catalog-backend": "^1.0.0",
-        "@backstage/plugin-scaffolder-common": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
+        "@backstage/plugin-catalog-backend": "^1.1.0",
+        "@backstage/plugin-scaffolder-common": "^1.0.1",
         "@backstage/types": "^1.0.0",
-        "@gitbeaker/core": "^34.6.0",
+        "@gitbeaker/core": "^35.6.0",
         "@gitbeaker/node": "^35.1.0",
         "@octokit/webhooks": "^9.14.1",
         "@types/express": "^4.17.6",
@@ -1713,7 +1787,7 @@
         "fs-extra": "10.0.1",
         "git-url-parse": "^11.6.0",
         "globby": "^11.0.0",
-        "isbinaryfile": "^4.0.8",
+        "isbinaryfile": "^5.0.0",
         "isomorphic-git": "^1.8.0",
         "jsonschema": "^1.2.6",
         "knex": "^1.0.2",
@@ -1732,26 +1806,70 @@
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/plugin-scaffolder-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.0.0.tgz",
-      "integrity": "sha512-vmlpdkbfMGiVycyyKYPeiDRzXJO/ruoMtsFLi1BTw/w5FXKB4NmP/+nUWomXC212ZjUqKvCza3OcpBgI5PztTw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.0.1.tgz",
+      "integrity": "sha512-V+m/F2YX0C3sslgAKV2Aoko0k4DfrZFOpIqDo/k0SAo9d4PhXlgEKtrZ6XHSioY9ouJYM3hk4f6sl+4oSinNEw==",
       "dependencies": {
-        "@backstage/catalog-model": "^1.0.0",
+        "@backstage/catalog-model": "^1.0.1",
         "@backstage/types": "^1.0.0"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/search-common": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@backstage/search-common/-/search-common-0.3.2.tgz",
-      "integrity": "sha512-CvkgpVnMrDJsZghsJiMjOWGf5O/9fROsGHnv24EHK8h724nShieALfyawfKsScnpjDLDXU0TIZFDGuXiP/wIUw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@backstage/search-common/-/search-common-0.3.3.tgz",
+      "integrity": "sha512-DtWd1Nrpvm2fkJRkw6bW8WeB6cFOvxsJ//o/fcoMsD5NCnaFtE1kFlCEt6QuUl6chAg6d+cX0rU+DJjSIC1rgQ==",
       "dependencies": {
-        "@backstage/plugin-search-common": "0.3.2"
+        "@backstage/plugin-search-common": "0.3.3"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@backstage/types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
       "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@gitbeaker/core": {
+      "version": "35.6.0",
+      "resolved": "https://registry.npmjs.org/@gitbeaker/core/-/core-35.6.0.tgz",
+      "integrity": "sha512-ZhaDUs/4BxHODfjRkVmwkWxZVaFIpYduxaj28+J+4FH9X93WZp0IsyT4szcFM7FwAbRW2+ZvGeEfw4NQwgB/RA==",
+      "dependencies": {
+        "@gitbeaker/requester-utils": "^35.6.0",
+        "form-data": "^4.0.0",
+        "li": "^1.3.0",
+        "mime": "^3.0.0",
+        "query-string": "^7.0.0",
+        "xcase": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.2.0"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/@gitbeaker/requester-utils": {
+      "version": "35.6.0",
+      "resolved": "https://registry.npmjs.org/@gitbeaker/requester-utils/-/requester-utils-35.6.0.tgz",
+      "integrity": "sha512-5IVzv1gO626qaC7CEV7LUG68IHgEjWovIHXQsbI9MraxhrI9eSV5/l/81Povv7tJlni7u8OnARPU7bmxlXlx7g==",
+      "dependencies": {
+        "form-data": "^4.0.0",
+        "qs": "^6.10.1",
+        "xcase": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.2.0"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/fs-extra": {
       "version": "10.0.1",
@@ -1764,6 +1882,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/isbinaryfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
+      "integrity": "sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
     "node_modules/@backstage/plugin-scaffolder-backend-module-cookiecutter/node_modules/typescript": {
@@ -1968,12 +2097,34 @@
       }
     },
     "node_modules/@backstage/plugin-search-common": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-search-common/-/plugin-search-common-0.3.2.tgz",
-      "integrity": "sha512-7vcpRo+5MB/QW/M77zPfcqxw0LzcQCHNXql0uxF+qBwVPJSHz9QB+YBuzGyaAlqfm5UPFXuweLQGqtoB+0DMLg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-search-common/-/plugin-search-common-0.3.3.tgz",
+      "integrity": "sha512-CARcpoMFEQJdpe+Rm9m/mPhMOsWM0V+zncIHOLuKlzsMrQRTcwmcFoPqBdtlfdT9wEJTu1bci2ccsDsnZiSrhA==",
       "dependencies": {
-        "@backstage/plugin-permission-common": "^0.5.3",
+        "@backstage/plugin-permission-common": "^0.6.0",
         "@backstage/types": "^1.0.0"
+      }
+    },
+    "node_modules/@backstage/plugin-search-common/node_modules/@backstage/errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@backstage/errors/-/errors-1.0.0.tgz",
+      "integrity": "sha512-2SpjdhH9ZOQ4RGEeu3/A7ARkl/1E9E6uBGQZ2DZOU4azTK1UZG/HE1KBMOThp3jL/8is2vOIJZLBA3r3DxLfVw==",
+      "dependencies": {
+        "@backstage/types": "^1.0.0",
+        "cross-fetch": "^3.1.5",
+        "serialize-error": "^8.0.1"
+      }
+    },
+    "node_modules/@backstage/plugin-search-common/node_modules/@backstage/plugin-permission-common": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.0.tgz",
+      "integrity": "sha512-wx5TUDFilRqmMJP8TxjR5GuulFFOPHNwoK6eNMuz5ESzLzPhiJDovqaXjqpxsdCVGNb2VJOUlND3SzbwjQ65aA==",
+      "dependencies": {
+        "@backstage/config": "^1.0.0",
+        "@backstage/errors": "^1.0.0",
+        "cross-fetch": "^3.1.5",
+        "uuid": "^8.0.0",
+        "zod": "^3.11.6"
       }
     },
     "node_modules/@backstage/plugin-search-common/node_modules/@backstage/types": {
@@ -2209,9 +2360,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.2.tgz",
-      "integrity": "sha512-0saiMeQkDALf9pvDD1rDZGV5aktUbnIWjm9jYiFKlxiMROJhODzaaltvyKg5oY6ujHv7Fzc5pzQVFo3R8vENpw==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.3.tgz",
+      "integrity": "sha512-l+8X0BoA7rg9jyZaS4p2DwMg1Ivju+VAL6PeQZE1u2q52LQ0KemrZmdQWhtrplHYo8UdYtqpbj4A6Fc5fKDZdg==",
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -2602,9 +2753,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2773,13 +2924,13 @@
       }
     },
     "node_modules/@octokit/auth-oauth-app": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.0.tgz",
-      "integrity": "sha512-cETmhmOQRHCz6cLP7StThlJROff3A/ln67Q961GuIr9zvyFXZ4lIJy9RE6Uw5O7D8IXWPU3jhDnG47FTSGQr8Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.1.tgz",
+      "integrity": "sha512-FXkKcGtTXS2987rp11mSuhMOXDw8Iy/ED9aXs83T29VeMEWjv40q4ytC0voUDxkBC/of1QYOPQUAdI2tv/dwNg==",
       "dependencies": {
         "@octokit/auth-oauth-device": "^3.1.1",
         "@octokit/auth-oauth-user": "^1.2.1",
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.3",
         "@octokit/types": "^6.0.3",
         "@types/btoa-lite": "^1.0.0",
         "btoa-lite": "^1.0.0",
@@ -3092,9 +3243,9 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A=="
+      "version": "8.10.94",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.94.tgz",
+      "integrity": "sha512-Y7Iih+LxURTJ8WTFqLWi2eF0G2oWz/tCkp0EQf0E1ikip1yfNtXOfgeXK3OaKA+/i6fAxvm9L1KPuTj8KBUB0A=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -3304,9 +3455,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.181",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
-      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -3384,6 +3535,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/webpack-env": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.4.tgz",
+      "integrity": "sha512-llS8qveOUX3wxHnSykP5hlYFFuMfJ9p5JvIyCiBgp7WTfl6K5ZcyHj8r8JsN/J6QODkAsRRCLIcTuOCu8etkUw=="
+    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -3400,14 +3556,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -3433,14 +3589,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -3460,13 +3616,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3477,12 +3633,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -3503,9 +3659,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3516,13 +3672,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -3543,15 +3699,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -3567,12 +3723,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3940,9 +4096,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1116.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1116.0.tgz",
-      "integrity": "sha512-36JFrxPPh/fRQWsgGrZZbzTxRu7dq4KyCKKXPxgVMXylEJsG/KEAVMB1f3eq4PiI5eGxYrpt2OkKoMQZQZLjPA==",
+      "version": "2.1118.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1118.0.tgz",
+      "integrity": "sha512-R3g06c4RC0Gz/lwMA7wgC7+FwYf5vaO30sPIigoX5m6Tfb7tdzfCYD7pnpvkPRNUvWJ3f5kQk+pEeW25DstRrQ==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -4909,9 +5065,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/core-js": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
-      "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.1.tgz",
+      "integrity": "sha512-l6CwCLq7XgITOQGhv1dIUmwCFoqFjyQ6zQHUCQlS0xKmb9d6OHIg8jDiEoswhaettT21BSF5qKr6kbvE+aKwxw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -5361,9 +5517,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.111",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
-      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
+      "version": "1.4.117",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.117.tgz",
+      "integrity": "sha512-ypZHxY+Sf/PXu7LVN+xoeanyisnJeSOy8Ki439L/oLueZb4c72FI45zXcK3gPpmTwyufh9m6NnbMLXnJh/0Fxg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -6988,9 +7144,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7341,9 +7497,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -7613,9 +7769,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-      "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -12704,15 +12860,15 @@
       },
       "dependencies": {
         "@backstage/backend-common": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-          "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+          "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
-            "@backstage/config-loader": "^1.0.0",
+            "@backstage/config-loader": "^1.1.0",
             "@backstage/errors": "^1.0.0",
-            "@backstage/integration": "^1.0.0",
+            "@backstage/integration": "^1.1.0",
             "@backstage/types": "^1.0.0",
             "@google-cloud/storage": "^5.8.0",
             "@keyv/redis": "^2.2.3",
@@ -12722,6 +12878,7 @@
             "@types/dockerode": "^3.3.0",
             "@types/express": "^4.17.6",
             "@types/luxon": "^2.0.4",
+            "@types/webpack-env": "^1.15.2",
             "archiver": "^5.0.2",
             "aws-sdk": "^2.840.0",
             "compression": "^1.7.4",
@@ -12756,30 +12913,30 @@
           }
         },
         "@backstage/catalog-model": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.0.tgz",
-          "integrity": "sha512-hjvTzs+P1/TG42FhX6jJvRIBbYZJC0vE9Qqn9MTb4n8vaoZuBT5jYTnK6K80gpEyNfbznpD5vsE8ss5lmzWz+Q==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.1.tgz",
+          "integrity": "sha512-VxKQ+WzcsxAWtwWyeGw04vTefkmwxi6XweXSNRhNddXAVqsAbDcCYBUc9jylu0bYVXXWYJkEl8kiwyawUloPPQ==",
           "requires": {
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
             "@backstage/types": "^1.0.0",
-            "ajv": "^7.0.3",
+            "ajv": "^8.10.0",
             "json-schema": "^0.4.0",
             "lodash": "^4.17.21",
             "uuid": "^8.0.0"
           }
         },
         "@backstage/config-loader": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-          "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+          "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
             "@backstage/types": "^1.0.0",
             "@types/json-schema": "^7.0.6",
-            "ajv": "^7.0.3",
+            "ajv": "^8.10.0",
             "chokidar": "^3.5.2",
             "fs-extra": "10.0.1",
             "json-schema": "^0.4.0",
@@ -12802,9 +12959,9 @@
           }
         },
         "@backstage/integration": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-          "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+          "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
           "requires": {
             "@backstage/config": "^1.0.0",
             "@octokit/auth-app": "^3.4.0",
@@ -12819,6 +12976,17 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
           "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+        },
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
         },
         "fs-extra": {
           "version": "10.0.1",
@@ -13055,15 +13223,15 @@
       },
       "dependencies": {
         "@backstage/backend-common": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-          "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+          "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
-            "@backstage/config-loader": "^1.0.0",
+            "@backstage/config-loader": "^1.1.0",
             "@backstage/errors": "^1.0.0",
-            "@backstage/integration": "^1.0.0",
+            "@backstage/integration": "^1.1.0",
             "@backstage/types": "^1.0.0",
             "@google-cloud/storage": "^5.8.0",
             "@keyv/redis": "^2.2.3",
@@ -13073,6 +13241,7 @@
             "@types/dockerode": "^3.3.0",
             "@types/express": "^4.17.6",
             "@types/luxon": "^2.0.4",
+            "@types/webpack-env": "^1.15.2",
             "archiver": "^5.0.2",
             "aws-sdk": "^2.840.0",
             "compression": "^1.7.4",
@@ -13107,16 +13276,16 @@
           }
         },
         "@backstage/config-loader": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-          "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+          "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
             "@backstage/types": "^1.0.0",
             "@types/json-schema": "^7.0.6",
-            "ajv": "^7.0.3",
+            "ajv": "^8.10.0",
             "chokidar": "^3.5.2",
             "fs-extra": "10.0.1",
             "json-schema": "^0.4.0",
@@ -13139,9 +13308,9 @@
           }
         },
         "@backstage/integration": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-          "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+          "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
           "requires": {
             "@backstage/config": "^1.0.0",
             "@octokit/auth-app": "^3.4.0",
@@ -13156,6 +13325,17 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
           "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+        },
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
         },
         "fs-extra": {
           "version": "10.0.1",
@@ -13356,15 +13536,15 @@
       }
     },
     "@backstage/plugin-scaffolder-backend-module-cookiecutter": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend-module-cookiecutter/-/plugin-scaffolder-backend-module-cookiecutter-0.2.5.tgz",
-      "integrity": "sha512-/44EU1AX9YIBo54jlVPCpHvMyMeD148UvAYhnTYJ9E4iE58MLdmSx6AyL0WSJ7VeODOyDvsy6xc4XOf+3+30PQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend-module-cookiecutter/-/plugin-scaffolder-backend-module-cookiecutter-0.2.6.tgz",
+      "integrity": "sha512-vp7yvk6hYzzYNzebSUOTfv4Ejd070s+9250RePBn7MYeJM7JWRjSzR948mxYIMnjpD+1C1AHmzMxWypo7BcsUA==",
       "requires": {
-        "@backstage/backend-common": "^0.13.1",
+        "@backstage/backend-common": "^0.13.2",
         "@backstage/config": "^1.0.0",
         "@backstage/errors": "^1.0.0",
-        "@backstage/integration": "^1.0.0",
-        "@backstage/plugin-scaffolder-backend": "^1.0.0",
+        "@backstage/integration": "^1.1.0",
+        "@backstage/plugin-scaffolder-backend": "^1.1.0",
         "@backstage/types": "^1.0.0",
         "command-exists": "^1.2.9",
         "fs-extra": "10.0.1",
@@ -13373,15 +13553,15 @@
       },
       "dependencies": {
         "@backstage/backend-common": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.1.tgz",
-          "integrity": "sha512-bZYj5WVGIsel6chK2EesBsACVmozAgTuODcsGo36eT5uxCl97WlQS7F8yBZyuBi6YunAwlQje28aH6+kHvijdA==",
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/@backstage/backend-common/-/backend-common-0.13.2.tgz",
+          "integrity": "sha512-FblxaHCw29N4ME1uHb+513EXcbn30vA224+6cj8159Wje2Rcv8EdMFtuf2awCNcYgoIdDD/R1wwBPeRmZhtERw==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
-            "@backstage/config-loader": "^1.0.0",
+            "@backstage/config-loader": "^1.1.0",
             "@backstage/errors": "^1.0.0",
-            "@backstage/integration": "^1.0.0",
+            "@backstage/integration": "^1.1.0",
             "@backstage/types": "^1.0.0",
             "@google-cloud/storage": "^5.8.0",
             "@keyv/redis": "^2.2.3",
@@ -13391,6 +13571,7 @@
             "@types/dockerode": "^3.3.0",
             "@types/express": "^4.17.6",
             "@types/luxon": "^2.0.4",
+            "@types/webpack-env": "^1.15.2",
             "archiver": "^5.0.2",
             "aws-sdk": "^2.840.0",
             "compression": "^1.7.4",
@@ -13425,40 +13606,40 @@
           }
         },
         "@backstage/catalog-client": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/catalog-client/-/catalog-client-1.0.0.tgz",
-          "integrity": "sha512-m2FiV9+gQElYrZMICFpr3Dj7H34as9Jly1onF/yFhKi4DSovZpgemTG6I0KQuNuEwmrqYTkTd6kDDYvpUis9Ow==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@backstage/catalog-client/-/catalog-client-1.0.1.tgz",
+          "integrity": "sha512-2JUEqtR3v361JM6JDjTt8k/tlZd27RB/ZQ2Vwp5seJf4QYXfR9s5AM4M35l/A5vosDKhGrxMAq3t2s4gcH9vVg==",
           "requires": {
-            "@backstage/catalog-model": "^1.0.0",
+            "@backstage/catalog-model": "^1.0.1",
             "@backstage/errors": "^1.0.0",
             "cross-fetch": "^3.1.5"
           }
         },
         "@backstage/catalog-model": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.0.tgz",
-          "integrity": "sha512-hjvTzs+P1/TG42FhX6jJvRIBbYZJC0vE9Qqn9MTb4n8vaoZuBT5jYTnK6K80gpEyNfbznpD5vsE8ss5lmzWz+Q==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@backstage/catalog-model/-/catalog-model-1.0.1.tgz",
+          "integrity": "sha512-VxKQ+WzcsxAWtwWyeGw04vTefkmwxi6XweXSNRhNddXAVqsAbDcCYBUc9jylu0bYVXXWYJkEl8kiwyawUloPPQ==",
           "requires": {
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
             "@backstage/types": "^1.0.0",
-            "ajv": "^7.0.3",
+            "ajv": "^8.10.0",
             "json-schema": "^0.4.0",
             "lodash": "^4.17.21",
             "uuid": "^8.0.0"
           }
         },
         "@backstage/config-loader": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.0.0.tgz",
-          "integrity": "sha512-gSC3hE+7oxXwWasuEBUOkX48ka84aZ8tQBUieU4NsP0R/b7YRspiE0bcynxsi9wzhwo2/waGy39iPnCqZRD6bg==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/config-loader/-/config-loader-1.1.0.tgz",
+          "integrity": "sha512-pZJz54pOSfZ5MC8vhDVrq1yM4p/T2O1iQNW5br5iv/e1JjHWpGt00yeZOxsHpsOeAfTl2JRpooUQQxpJQ47uUQ==",
           "requires": {
             "@backstage/cli-common": "^0.1.8",
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
             "@backstage/types": "^1.0.0",
             "@types/json-schema": "^7.0.6",
-            "ajv": "^7.0.3",
+            "ajv": "^8.10.0",
             "chokidar": "^3.5.2",
             "fs-extra": "10.0.1",
             "json-schema": "^0.4.0",
@@ -13481,9 +13662,9 @@
           }
         },
         "@backstage/integration": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.0.0.tgz",
-          "integrity": "sha512-DpEoSCQyurLSNGLAAfZzwb8IGEoxm6po6ZkKq9Gt9I63NbLhixBEnCcoPbm5+ld4MVNwg+FgzIoktsjdBt3JIw==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/integration/-/integration-1.1.0.tgz",
+          "integrity": "sha512-2yf1ioFsbivHf/PtQy66WT7pa9Mzazc44OORDO4EFEsJT4noIZHff2NZfHvg/5dFFQPPPY/esyEf83jhsOE7Wg==",
           "requires": {
             "@backstage/config": "^1.0.0",
             "@octokit/auth-app": "^3.4.0",
@@ -13494,22 +13675,35 @@
             "luxon": "^2.0.2"
           }
         },
-        "@backstage/plugin-catalog-backend": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.0.0.tgz",
-          "integrity": "sha512-YFZpRiJPVl38wFbb/IM8Sb1xTdXfXhH3AHNhuO/M38l3I2ThkhJnkUt3QWA+mIyf0k2q0xtawvjJU/6pqwAo6A==",
+        "@backstage/plugin-auth-node": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-auth-node/-/plugin-auth-node-0.2.0.tgz",
+          "integrity": "sha512-aYfC3Hx9De78gofRB0DAIjyTD09XnRLxbjK2JCz9An6eVdX/DOWI8iwwNN07Qem0haLsGNVBhofUuuqQYpfw8w==",
           "requires": {
-            "@backstage/backend-common": "^0.13.1",
-            "@backstage/catalog-client": "^1.0.0",
-            "@backstage/catalog-model": "^1.0.0",
+            "@backstage/backend-common": "^0.13.2",
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
-            "@backstage/integration": "^1.0.0",
-            "@backstage/plugin-catalog-common": "^1.0.0",
-            "@backstage/plugin-permission-common": "^0.5.3",
-            "@backstage/plugin-permission-node": "^0.5.5",
-            "@backstage/plugin-scaffolder-common": "^1.0.0",
-            "@backstage/plugin-search-common": "^0.3.2",
+            "jose": "^1.27.1",
+            "node-fetch": "^2.6.7",
+            "winston": "^3.2.1"
+          }
+        },
+        "@backstage/plugin-catalog-backend": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-backend/-/plugin-catalog-backend-1.1.1.tgz",
+          "integrity": "sha512-o81MnzcdAY3vWyH2H//vHyI/dYQhfXf21PylGPLdDqQgHuxh9yNeM7OlKSeqmpbHBVkvl+vjzrpZUTmrNvKMQg==",
+          "requires": {
+            "@backstage/backend-common": "^0.13.2",
+            "@backstage/catalog-client": "^1.0.1",
+            "@backstage/catalog-model": "^1.0.1",
+            "@backstage/config": "^1.0.0",
+            "@backstage/errors": "^1.0.0",
+            "@backstage/integration": "^1.1.0",
+            "@backstage/plugin-catalog-common": "^1.0.1",
+            "@backstage/plugin-permission-common": "^0.6.0",
+            "@backstage/plugin-permission-node": "^0.6.0",
+            "@backstage/plugin-scaffolder-common": "^1.0.1",
+            "@backstage/plugin-search-common": "^0.3.3",
             "@backstage/types": "^1.0.0",
             "@types/express": "^4.17.6",
             "codeowners-utils": "^1.0.2",
@@ -13534,29 +13728,57 @@
           }
         },
         "@backstage/plugin-catalog-common": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.0.tgz",
-          "integrity": "sha512-XKBMlh/2RMJ8Nkc6n/hYS07To+MVe2oCp3tHJpmXYzYe0Uc8nfE09iam26n9Kz/mtcmlIP2LJcjYW2mq1k2vnA==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.1.tgz",
+          "integrity": "sha512-zPf8OGSjH+ZftMnjBxTgwLtgapnO1L7fzulLQ2RRaWrUcXGk8N3szQBDcqwxfBFiWSIX1G4vvRi/BGXFMUMlnw==",
           "requires": {
-            "@backstage/plugin-permission-common": "^0.5.3",
-            "@backstage/search-common": "^0.3.2"
+            "@backstage/plugin-permission-common": "^0.6.0",
+            "@backstage/search-common": "^0.3.3"
+          }
+        },
+        "@backstage/plugin-permission-common": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.0.tgz",
+          "integrity": "sha512-wx5TUDFilRqmMJP8TxjR5GuulFFOPHNwoK6eNMuz5ESzLzPhiJDovqaXjqpxsdCVGNb2VJOUlND3SzbwjQ65aA==",
+          "requires": {
+            "@backstage/config": "^1.0.0",
+            "@backstage/errors": "^1.0.0",
+            "cross-fetch": "^3.1.5",
+            "uuid": "^8.0.0",
+            "zod": "^3.11.6"
+          }
+        },
+        "@backstage/plugin-permission-node": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-node/-/plugin-permission-node-0.6.0.tgz",
+          "integrity": "sha512-3NUa+0YjYZ9N0MqyKMTsnfrxzCtcahZVPowEXduELvqJ/L4K6pRFFwI+/g+wmLXKmt72eDceuwEa/ZEFsxbKTg==",
+          "requires": {
+            "@backstage/backend-common": "^0.13.2",
+            "@backstage/config": "^1.0.0",
+            "@backstage/errors": "^1.0.0",
+            "@backstage/plugin-auth-node": "^0.2.0",
+            "@backstage/plugin-permission-common": "^0.6.0",
+            "@types/express": "^4.17.6",
+            "express": "^4.17.1",
+            "express-promise-router": "^4.1.0",
+            "zod": "^3.11.6"
           }
         },
         "@backstage/plugin-scaffolder-backend": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend/-/plugin-scaffolder-backend-1.0.0.tgz",
-          "integrity": "sha512-XBO0xEYJKml2pZ4Akkgt47SmGN4p6seQCBmWKcOzm6lYtjAPV4dxv5JlwNWmoQDJ1KCNh2/hmuBAcoWIIZl/nA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-backend/-/plugin-scaffolder-backend-1.1.0.tgz",
+          "integrity": "sha512-Jt1TthxzxxfxOGh46ZkmHFmdGl48tyObgO5MCqntoITzp5Plbm0/Kx4jwAJ3CFfLonulJ+tA91g63MBOYueugw==",
           "requires": {
-            "@backstage/backend-common": "^0.13.1",
-            "@backstage/catalog-client": "^1.0.0",
-            "@backstage/catalog-model": "^1.0.0",
+            "@backstage/backend-common": "^0.13.2",
+            "@backstage/catalog-client": "^1.0.1",
+            "@backstage/catalog-model": "^1.0.1",
             "@backstage/config": "^1.0.0",
             "@backstage/errors": "^1.0.0",
-            "@backstage/integration": "^1.0.0",
-            "@backstage/plugin-catalog-backend": "^1.0.0",
-            "@backstage/plugin-scaffolder-common": "^1.0.0",
+            "@backstage/integration": "^1.1.0",
+            "@backstage/plugin-catalog-backend": "^1.1.0",
+            "@backstage/plugin-scaffolder-common": "^1.0.1",
             "@backstage/types": "^1.0.0",
-            "@gitbeaker/core": "^34.6.0",
+            "@gitbeaker/core": "^35.6.0",
             "@gitbeaker/node": "^35.1.0",
             "@octokit/webhooks": "^9.14.1",
             "@types/express": "^4.17.6",
@@ -13569,7 +13791,7 @@
             "fs-extra": "10.0.1",
             "git-url-parse": "^11.6.0",
             "globby": "^11.0.0",
-            "isbinaryfile": "^4.0.8",
+            "isbinaryfile": "^5.0.0",
             "isomorphic-git": "^1.8.0",
             "jsonschema": "^1.2.6",
             "knex": "^1.0.2",
@@ -13588,26 +13810,60 @@
           }
         },
         "@backstage/plugin-scaffolder-common": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.0.0.tgz",
-          "integrity": "sha512-vmlpdkbfMGiVycyyKYPeiDRzXJO/ruoMtsFLi1BTw/w5FXKB4NmP/+nUWomXC212ZjUqKvCza3OcpBgI5PztTw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.0.1.tgz",
+          "integrity": "sha512-V+m/F2YX0C3sslgAKV2Aoko0k4DfrZFOpIqDo/k0SAo9d4PhXlgEKtrZ6XHSioY9ouJYM3hk4f6sl+4oSinNEw==",
           "requires": {
-            "@backstage/catalog-model": "^1.0.0",
+            "@backstage/catalog-model": "^1.0.1",
             "@backstage/types": "^1.0.0"
           }
         },
         "@backstage/search-common": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@backstage/search-common/-/search-common-0.3.2.tgz",
-          "integrity": "sha512-CvkgpVnMrDJsZghsJiMjOWGf5O/9fROsGHnv24EHK8h724nShieALfyawfKsScnpjDLDXU0TIZFDGuXiP/wIUw==",
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@backstage/search-common/-/search-common-0.3.3.tgz",
+          "integrity": "sha512-DtWd1Nrpvm2fkJRkw6bW8WeB6cFOvxsJ//o/fcoMsD5NCnaFtE1kFlCEt6QuUl6chAg6d+cX0rU+DJjSIC1rgQ==",
           "requires": {
-            "@backstage/plugin-search-common": "0.3.2"
+            "@backstage/plugin-search-common": "0.3.3"
           }
         },
         "@backstage/types": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
           "integrity": "sha512-x5650F/lXUO1Bo++Eg1T9vreuIzlOeljxTUCP6mxqOGgOWr8yBku42HiHX6KE80OpckFDTUyKtEWqboclfKUkg=="
+        },
+        "@gitbeaker/core": {
+          "version": "35.6.0",
+          "resolved": "https://registry.npmjs.org/@gitbeaker/core/-/core-35.6.0.tgz",
+          "integrity": "sha512-ZhaDUs/4BxHODfjRkVmwkWxZVaFIpYduxaj28+J+4FH9X93WZp0IsyT4szcFM7FwAbRW2+ZvGeEfw4NQwgB/RA==",
+          "requires": {
+            "@gitbeaker/requester-utils": "^35.6.0",
+            "form-data": "^4.0.0",
+            "li": "^1.3.0",
+            "mime": "^3.0.0",
+            "query-string": "^7.0.0",
+            "xcase": "^2.0.1"
+          }
+        },
+        "@gitbeaker/requester-utils": {
+          "version": "35.6.0",
+          "resolved": "https://registry.npmjs.org/@gitbeaker/requester-utils/-/requester-utils-35.6.0.tgz",
+          "integrity": "sha512-5IVzv1gO626qaC7CEV7LUG68IHgEjWovIHXQsbI9MraxhrI9eSV5/l/81Povv7tJlni7u8OnARPU7bmxlXlx7g==",
+          "requires": {
+            "form-data": "^4.0.0",
+            "qs": "^6.10.1",
+            "xcase": "^2.0.1"
+          }
+        },
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
         },
         "fs-extra": {
           "version": "10.0.1",
@@ -13618,6 +13874,11 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
+        },
+        "isbinaryfile": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
+          "integrity": "sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg=="
         },
         "typescript": {
           "version": "4.5.5",
@@ -13694,14 +13955,36 @@
       }
     },
     "@backstage/plugin-search-common": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@backstage/plugin-search-common/-/plugin-search-common-0.3.2.tgz",
-      "integrity": "sha512-7vcpRo+5MB/QW/M77zPfcqxw0LzcQCHNXql0uxF+qBwVPJSHz9QB+YBuzGyaAlqfm5UPFXuweLQGqtoB+0DMLg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@backstage/plugin-search-common/-/plugin-search-common-0.3.3.tgz",
+      "integrity": "sha512-CARcpoMFEQJdpe+Rm9m/mPhMOsWM0V+zncIHOLuKlzsMrQRTcwmcFoPqBdtlfdT9wEJTu1bci2ccsDsnZiSrhA==",
       "requires": {
-        "@backstage/plugin-permission-common": "^0.5.3",
+        "@backstage/plugin-permission-common": "^0.6.0",
         "@backstage/types": "^1.0.0"
       },
       "dependencies": {
+        "@backstage/errors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@backstage/errors/-/errors-1.0.0.tgz",
+          "integrity": "sha512-2SpjdhH9ZOQ4RGEeu3/A7ARkl/1E9E6uBGQZ2DZOU4azTK1UZG/HE1KBMOThp3jL/8is2vOIJZLBA3r3DxLfVw==",
+          "requires": {
+            "@backstage/types": "^1.0.0",
+            "cross-fetch": "^3.1.5",
+            "serialize-error": "^8.0.1"
+          }
+        },
+        "@backstage/plugin-permission-common": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.0.tgz",
+          "integrity": "sha512-wx5TUDFilRqmMJP8TxjR5GuulFFOPHNwoK6eNMuz5ESzLzPhiJDovqaXjqpxsdCVGNb2VJOUlND3SzbwjQ65aA==",
+          "requires": {
+            "@backstage/config": "^1.0.0",
+            "@backstage/errors": "^1.0.0",
+            "cross-fetch": "^3.1.5",
+            "uuid": "^8.0.0",
+            "zod": "^3.11.6"
+          }
+        },
         "@backstage/types": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@backstage/types/-/types-1.0.0.tgz",
@@ -13898,9 +14181,9 @@
       "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
     },
     "@google-cloud/storage": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.2.tgz",
-      "integrity": "sha512-0saiMeQkDALf9pvDD1rDZGV5aktUbnIWjm9jYiFKlxiMROJhODzaaltvyKg5oY6ujHv7Fzc5pzQVFo3R8vENpw==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.3.tgz",
+      "integrity": "sha512-l+8X0BoA7rg9jyZaS4p2DwMg1Ivju+VAL6PeQZE1u2q52LQ0KemrZmdQWhtrplHYo8UdYtqpbj4A6Fc5fKDZdg==",
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -14222,9 +14505,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -14373,13 +14656,13 @@
       }
     },
     "@octokit/auth-oauth-app": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.0.tgz",
-      "integrity": "sha512-cETmhmOQRHCz6cLP7StThlJROff3A/ln67Q961GuIr9zvyFXZ4lIJy9RE6Uw5O7D8IXWPU3jhDnG47FTSGQr8Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.1.tgz",
+      "integrity": "sha512-FXkKcGtTXS2987rp11mSuhMOXDw8Iy/ED9aXs83T29VeMEWjv40q4ytC0voUDxkBC/of1QYOPQUAdI2tv/dwNg==",
       "requires": {
         "@octokit/auth-oauth-device": "^3.1.1",
         "@octokit/auth-oauth-user": "^1.2.1",
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.3",
         "@octokit/types": "^6.0.3",
         "@types/btoa-lite": "^1.0.0",
         "btoa-lite": "^1.0.0",
@@ -14666,9 +14949,9 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A=="
+      "version": "8.10.94",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.94.tgz",
+      "integrity": "sha512-Y7Iih+LxURTJ8WTFqLWi2eF0G2oWz/tCkp0EQf0E1ikip1yfNtXOfgeXK3OaKA+/i6fAxvm9L1KPuTj8KBUB0A=="
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -14878,9 +15161,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.181",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
-      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "@types/lru-cache": {
       "version": "5.1.1",
@@ -14958,6 +15241,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/webpack-env": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.4.tgz",
+      "integrity": "sha512-llS8qveOUX3wxHnSykP5hlYFFuMfJ9p5JvIyCiBgp7WTfl6K5ZcyHj8r8JsN/J6QODkAsRRCLIcTuOCu8etkUw=="
+    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -14974,14 +15262,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -14991,52 +15279,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -15045,26 +15333,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -15347,9 +15635,9 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-sdk": {
-      "version": "2.1116.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1116.0.tgz",
-      "integrity": "sha512-36JFrxPPh/fRQWsgGrZZbzTxRu7dq4KyCKKXPxgVMXylEJsG/KEAVMB1f3eq4PiI5eGxYrpt2OkKoMQZQZLjPA==",
+      "version": "2.1118.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1118.0.tgz",
+      "integrity": "sha512-R3g06c4RC0Gz/lwMA7wgC7+FwYf5vaO30sPIigoX5m6Tfb7tdzfCYD7pnpvkPRNUvWJ3f5kQk+pEeW25DstRrQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -16090,9 +16378,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
-      "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ=="
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.1.tgz",
+      "integrity": "sha512-l6CwCLq7XgITOQGhv1dIUmwCFoqFjyQ6zQHUCQlS0xKmb9d6OHIg8jDiEoswhaettT21BSF5qKr6kbvE+aKwxw=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -16437,9 +16725,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.4.111",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
-      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
+      "version": "1.4.117",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.117.tgz",
+      "integrity": "sha512-ypZHxY+Sf/PXu7LVN+xoeanyisnJeSOy8Ki439L/oLueZb4c72FI45zXcK3gPpmTwyufh9m6NnbMLXnJh/0Fxg==",
       "dev": true
     },
     "emittery": {
@@ -17663,9 +17951,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -17913,9 +18201,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -18098,9 +18386,9 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-      "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._