### PR TITLE
fix: skip semantic release dry run for dependabot

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -10,6 +10,7 @@ jobs:
           fetch-depth: 0
       - name: Dry-run release
         uses: tradeshift/actions-semantic-release@v1
+        if: ${{ github.actor != 'dependabot[bot]' }}
         id: semantic-release
         with:
           branches: |


### PR DESCRIPTION
Dependabot lack some write permissionsn to make labels on PR's etc